### PR TITLE
Add GetBuildID method. Add some retries to api calls

### DIFF
--- a/client.go
+++ b/client.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
+	"time"
 )
 
 // Client to access a TeamCity API
@@ -44,7 +46,11 @@ func (c *Client) QueueBuild(buildTypeID string, branchName string, properties ma
 	}
 
 	build := &Build{}
-	err := c.doRequest("POST", "/httpAuth/app/rest/buildQueue", jsonQuery, &build)
+
+	retries := 8
+	err := withRetry(retries, func() error {
+		return c.doRequest("POST", "/httpAuth/app/rest/buildQueue", jsonQuery, &build)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -55,13 +61,16 @@ func (c *Client) QueueBuild(buildTypeID string, branchName string, properties ma
 }
 
 func (c *Client) SearchBuild(locator string) ([]*Build, error) {
-	path := fmt.Sprintf("/httpAuth/app/rest/builds/?locator=%s&fields=count,build(*,tags(tag),triggered(*),properties(property))", locator)
+	path := fmt.Sprintf("/httpAuth/app/rest/builds/?locator=%s&fields=count,build(*,tags(tag),triggered(*),properties(property),problemOccurrences(*,problemOccurrence(*)),testOccurrences(*,testOccurrence(*)),changes(*,change(*)))", locator)
 
 	respStruct := struct {
 		Count int
 		Build []*Build
 	}{}
-	err := c.doRequest("GET", path, nil, &respStruct)
+	retries := 8
+	err := withRetry(retries, func() error {
+		return c.doRequest("GET", path, nil, &respStruct)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -74,9 +83,14 @@ func (c *Client) SearchBuild(locator string) ([]*Build, error) {
 }
 
 func (c *Client) GetBuild(buildID string) (*Build, error) {
-	path := fmt.Sprintf("/httpAuth/app/rest/builds/id:%s", buildID)
+	path := fmt.Sprintf("/httpAuth/app/rest/builds/id:%s?fields=*,tags(tag),triggered(*),properties(property),problemOccurrences(*,problemOccurrence(*)),testOccurrences(*,testOccurrence(*)),changes(*,change(*))", buildID)
 	var build *Build
-	err := c.doRequest("GET", path, nil, &build)
+
+	retries := 8
+	err := withRetry(retries, func() error {
+		return c.doRequest("GET", path, nil, &build)
+	})
+
 	if err != nil {
 		return nil, err
 	}
@@ -88,13 +102,43 @@ func (c *Client) GetBuild(buildID string) (*Build, error) {
 	return build, nil
 }
 
+func (c *Client) GetBuildID(buildTypeID, branchName, buildNumber string) (string, error) {
+	type builds struct {
+		Count    int
+		Href     string
+		NextHref string
+		Build    []Build
+	}
+
+	path := fmt.Sprintf("/httpAuth/app/rest/buildTypes/id:%s/builds?locator=branch:%s,number:%s,count:1", buildTypeID, branchName, buildNumber)
+
+	var build *builds
+	retries := 8
+	err := withRetry(retries, func() error {
+		return c.doRequest("GET", path, nil, &build)
+	})
+	if err != nil {
+		return "ID not found", err
+	}
+
+	if build == nil {
+		return "ID not found", errors.New("build not found")
+	}
+
+	return fmt.Sprintf("%d", build.Build[0].ID), nil
+}
+
 func (c *Client) GetBuildProperties(buildID string) (map[string]string, error) {
 	path := fmt.Sprintf("/httpAuth/app/rest/builds/id:%s/resulting-properties", buildID)
 
 	var response struct {
 		Property []oneProperty `json:"property,omitempty"`
 	}
-	err := c.doRequest("GET", path, nil, &response)
+
+	retries := 8
+	err := withRetry(retries, func() error {
+		return c.doRequest("GET", path, nil, &response)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -111,6 +155,7 @@ func (c *Client) GetChanges(path string) ([]Change, error) {
 		Change []Change
 	}
 
+	path += ",count:99999"
 	err := c.doRequest("GET", path, nil, &changes)
 	if err != nil {
 		return nil, err
@@ -121,6 +166,48 @@ func (c *Client) GetChanges(path string) ([]Change, error) {
 	}
 
 	return changes.Change, nil
+}
+
+func (c *Client) GetProblems(path string, count int64) ([]ProblemOccurrence, error) {
+	var problems struct {
+		Count             int64
+		Default           bool
+		ProblemOccurrence []ProblemOccurrence
+	}
+
+	path += fmt.Sprintf(",count:%v&fields=*,problemOccurrence(*,details)", count)
+	err := c.doRequest("GET", path, nil, &problems)
+	if err != nil {
+		return nil, err
+	}
+
+	if problems.ProblemOccurrence == nil {
+		return nil, errors.New("problemOccurrence list not found")
+	}
+
+	return problems.ProblemOccurrence, nil
+}
+
+func (c *Client) GetTests(path string, count int64, failingOnly bool, ignoreMuted bool) ([]TestOccurrence, error) {
+	var tests struct {
+		Count          int64
+		HREF           string
+		TestOccurrence []TestOccurrence
+	}
+
+	if ignoreMuted {
+		path += ",currentlyMuted:false"
+	}
+	if failingOnly {
+		path += ",status:FAILURE"
+	}
+	path += fmt.Sprintf(",count:%v", count)
+	err := c.doRequest("GET", path, nil, &tests)
+	if err != nil {
+		return nil, err
+	}
+
+	return tests.TestOccurrence, nil
 }
 
 func (c *Client) CancelBuild(buildID int64, comment string) error {
@@ -167,7 +254,7 @@ func (c *Client) doRequest(method string, path string, data interface{}, v inter
 		return err
 	}
 
-	//ioutil.WriteFile(fmt.Sprintf("/tmp/mama-%s.json", time.Now().Format("15:04:05.000")), jsonCnt, 0644)
+	ioutil.WriteFile(fmt.Sprintf("/tmp/mama-%s.json", time.Now().Format("15h04m05.000")), jsonCnt, 0644)
 
 	if v != nil {
 		err = json.Unmarshal(jsonCnt, &v)
@@ -184,4 +271,16 @@ func truncate(s string, l int) string {
 		return s[:l]
 	}
 	return s
+}
+
+func withRetry(retries int, f func() error) (err error) {
+	for i := 0; i < retries; i++ {
+		err = f()
+		if err != nil {
+			log.Printf("Retry: %v / %v, error: %v\n", i, retries, err)
+		} else {
+			return
+		}
+	}
+	return
 }

--- a/problems.go
+++ b/problems.go
@@ -1,0 +1,9 @@
+package teamcity
+
+type ProblemOccurrence struct {
+	ID       string
+	Type     string
+	Identity string
+	HREF     string
+	Details  string
+}

--- a/problems_test.go
+++ b/problems_test.go
@@ -1,0 +1,38 @@
+package teamcity
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+var JSONresponse = []byte(`{
+  "count": 1,
+  "href": "https://teamcity-or.intel.com/app/rest/problemOccurrences?locator=build:(id:431935)",
+  "problemOccurrence": [
+    {
+      "id": "problem:(id:135),build:(id:431935)",
+      "type": "TC_FAILED_TESTS",
+      "identity": "TC_FAILED_TESTS",
+      "href": "/httpAuth/app/rest/problemOccurrences/problem:(id:135),build:(id:431935)"
+    }
+  ],
+  "default": false
+}`)
+
+func TestResponseParsing(t *testing.T) {
+	var v struct {
+		Count             int64
+		Default           bool
+		HREF              string
+		ProblemOccurrence ProblemOccurrence
+	}
+
+	err := json.Unmarshal(JSONresponse, &v)
+	if err != nil {
+		t.Errorf("json unmarshal: %s", err)
+	}
+
+	fmt.Printf("%#v", v)
+
+}

--- a/tests.go
+++ b/tests.go
@@ -1,0 +1,13 @@
+package teamcity
+
+type TestOccurrence struct {
+	ID                    string
+	Name                  string
+	Status                string
+	Muted                 bool
+	Duration              int64
+	CurrentlyMuted        bool
+	CurrentlyInvestigated bool
+	HREF                  string
+	Details               string
+}


### PR DESCRIPTION
The `GetBuildID` method takes the buildTypeID, branchName and buildNumber and returns the buildID.

All the call to the api are retried up to 8 times if an error occured
